### PR TITLE
Push errror mensaje config 

### DIFF
--- a/.github/workflows/test-2.10.yml
+++ b/.github/workflows/test-2.10.yml
@@ -1,5 +1,5 @@
 name: Tests CKAN 2.10
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-2.11.yml
+++ b/.github/workflows/test-2.11.yml
@@ -1,5 +1,5 @@
 name: Tests CKAN 2.11
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/ckanext/push_errors/logging.py
+++ b/ckanext/push_errors/logging.py
@@ -115,7 +115,7 @@ def push_message(message, extra_context={}):
 
     # Allow multiple headers in config
     # Decoding headers
-    headers_str = toolkit.config.get('ckanext.push_errors.headers', '{}')
+    headers_str = toolkit.config.get('ckanext.push_errors.headers', '{}') or '{}'
     try:
         headers = json.loads(headers_str)
     except json.JSONDecodeError:
@@ -127,7 +127,7 @@ def push_message(message, extra_context={}):
         headers[key] = value.format(**ctx)
 
     # Decoding data
-    data = toolkit.config.get('ckanext.push_errors.data', '{}')
+    data = toolkit.config.get('ckanext.push_errors.data', '{}') or '{}'
     try:
         data = json.loads(data)
     except json.JSONDecodeError:

--- a/ckanext/push_errors/logging.py
+++ b/ckanext/push_errors/logging.py
@@ -17,6 +17,7 @@ def can_send_message():
     Verifica si se puede enviar una nueva notificación según los límites definidos.
     """
     cache = get_cache()
+    vals = ""
     for cfg in [
         'ckanext.push_errors.max_messages_minute',
         'ckanext.push_errors.max_messages_hour',
@@ -27,9 +28,12 @@ def can_send_message():
         'ckanext.push_errors.title'
     ]:
         val = toolkit.config.get(cfg)
-        print(f'cfg: {cfg} == {val}')
-    limit_minute = int(toolkit.config.get('ckanext.push_errors.max_messages_minute', 3))  # Default: 3
-    limit_hour = int(toolkit.config.get('ckanext.push_errors.max_messages_hour', 10))    # Default: 10
+        vals += (f'cfg: {cfg} == {val}\n')
+    try:
+        limit_minute = int(toolkit.config.get('ckanext.push_errors.max_messages_minute', 3))  # Default: 3
+        limit_hour = int(toolkit.config.get('ckanext.push_errors.max_messages_hour', 10))    # Default: 10
+    except Exception as e:
+        raise Exception(f'ERROR: {e}: {vals}')
 
     current_minute = datetime.now().strftime('%Y%m%d%H%M')
     current_hour = datetime.now().strftime('%Y%m%d%H')

--- a/ckanext/push_errors/logging.py
+++ b/ckanext/push_errors/logging.py
@@ -17,6 +17,17 @@ def can_send_message():
     Verifica si se puede enviar una nueva notificación según los límites definidos.
     """
     cache = get_cache()
+    for cfg in [
+        'ckanext.push_errors.max_messages_minute',
+        'ckanext.push_errors.max_messages_hour',
+        'ckanext.push_errors.url',
+        'ckanext.push_errors.method',
+        'ckanext.push_errors.headers',
+        'ckanext.push_errors.data',
+        'ckanext.push_errors.title'
+    ]:
+        val = toolkit.config.get(cfg)
+        print(f'cfg: {cfg} == {val}')
     limit_minute = int(toolkit.config.get('ckanext.push_errors.max_messages_minute', 3))  # Default: 3
     limit_hour = int(toolkit.config.get('ckanext.push_errors.max_messages_hour', 10))    # Default: 10
 

--- a/ckanext/push_errors/logging.py
+++ b/ckanext/push_errors/logging.py
@@ -17,23 +17,8 @@ def can_send_message():
     Verifica si se puede enviar una nueva notificación según los límites definidos.
     """
     cache = get_cache()
-    vals = ""
-    for cfg in [
-        'ckanext.push_errors.max_messages_minute',
-        'ckanext.push_errors.max_messages_hour',
-        'ckanext.push_errors.url',
-        'ckanext.push_errors.method',
-        'ckanext.push_errors.headers',
-        'ckanext.push_errors.data',
-        'ckanext.push_errors.title'
-    ]:
-        val = toolkit.config.get(cfg)
-        vals += (f'cfg: {cfg} == {val}\n')
-    try:
-        limit_minute = int(toolkit.config.get('ckanext.push_errors.max_messages_minute', 3))  # Default: 3
-        limit_hour = int(toolkit.config.get('ckanext.push_errors.max_messages_hour', 10))    # Default: 10
-    except Exception as e:
-        raise Exception(f'ERROR: {e}: {vals}')
+    limit_minute = int(toolkit.config.get('ckanext.push_errors.max_messages_minute', 3))  # Default: 3
+    limit_hour = int(toolkit.config.get('ckanext.push_errors.max_messages_hour', 10))    # Default: 10
 
     current_minute = datetime.now().strftime('%Y%m%d%H%M')
     current_hour = datetime.now().strftime('%Y%m%d%H')

--- a/ckanext/push_errors/tests/test_push_menssage.py
+++ b/ckanext/push_errors/tests/test_push_menssage.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch, MagicMock
+from ckanext.push_errors.logging import push_message
+
+
+@patch('ckanext.push_errors.logging.toolkit')
+@patch('ckanext.push_errors.logging.requests.post')
+def test_push_message_success(mock_post, mock_toolkit):
+    # Configuración de mocks
+    mock_toolkit.config.get.side_effect = lambda key, default=None: {
+        'ckanext.push_errors.url': 'https://fake-url.org',
+        'ckan.site_url': 'https://mysite.org',
+        'ckanext.push_errors.method': 'POST',
+        'ckanext.push_errors.headers': '{}',
+        'ckanext.push_errors.data': '{}',
+        'ckanext.push_errors.message_title': 'Test Message {site_url} - {now}'
+    }.get(key, default)
+
+    # Simular respuesta exitosa
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = 'Message received'
+    mock_post.return_value = mock_response
+
+    # Ejecutar la función
+    response = push_message("Este es un mensaje de prueba")
+
+    # Verificar que la llamada se hizo correctamente
+    mock_post.assert_called_once()
+    assert response.status_code == 200
+    assert 'Message received' in response.text
+
+
+@patch('ckanext.push_errors.logging.toolkit')
+@patch('ckanext.push_errors.logging.requests.post')
+def test_push_message_no_url(mock_post, mock_toolkit):
+    # Configuración sin URL
+    mock_toolkit.config.get.return_value = None
+
+    response = push_message("Mensaje sin URL")
+
+    # Verificar que no se hizo ninguna solicitud
+    mock_post.assert_not_called()
+    assert response is None

--- a/ckanext/push_errors/tests/test_push_message.py
+++ b/ckanext/push_errors/tests/test_push_message.py
@@ -2,18 +2,8 @@ from unittest.mock import patch, MagicMock
 from ckanext.push_errors.logging import push_message
 
 
-@patch('ckanext.push_errors.logging.toolkit')
 @patch('ckanext.push_errors.logging.requests.post')
-def test_push_message_success(mock_post, mock_toolkit):
-    # Configuración de mocks
-    mock_toolkit.config.get.side_effect = lambda key, default=None: {
-        'ckanext.push_errors.url': 'https://fake-url.org',
-        'ckan.site_url': 'https://mysite.org',
-        'ckanext.push_errors.method': 'POST',
-        'ckanext.push_errors.headers': '{}',
-        'ckanext.push_errors.data': '{}',
-        'ckanext.push_errors.message_title': 'Test Message {site_url} - {now}'
-    }.get(key, default)
+def test_push_message_success(mock_post):
 
     # Simular respuesta exitosa
     mock_response = MagicMock()

--- a/ckanext/push_errors/tests/test_push_message.py
+++ b/ckanext/push_errors/tests/test_push_message.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, MagicMock
+import pytest
 from ckanext.push_errors.logging import push_message
 
 
@@ -20,6 +21,7 @@ def test_push_message_success(mock_post):
     assert 'Message received' in response.text
 
 
+@pytest.mark.ckan_config("ckanext.push_errors.url", "")
 @patch('ckanext.push_errors.logging.toolkit')
 @patch('ckanext.push_errors.logging.requests.post')
 def test_push_message_no_url(mock_post, mock_toolkit):

--- a/ckanext/push_errors/tests/test_push_message.py
+++ b/ckanext/push_errors/tests/test_push_message.py
@@ -22,13 +22,11 @@ def test_push_message_success(mock_post):
 
 
 @pytest.mark.ckan_config("ckanext.push_errors.url", "")
-@patch('ckanext.push_errors.logging.toolkit')
 @patch('ckanext.push_errors.logging.requests.post')
-def test_push_message_no_url(mock_post, mock_toolkit):
+def test_push_message_no_url(mock_post):
     # Configuración sin URL
-    mock_toolkit.config.get.return_value = None
 
-    response = push_message("Mensaje sin URL")
+    response = push_message("Missing URL")
 
     # Verificar que no se hizo ninguna solicitud
     mock_post.assert_not_called()

--- a/test.ini
+++ b/test.ini
@@ -4,7 +4,7 @@ smtp_server = localhost
 error_email_from = ckan@localhost
 
 [app:main]
-use = config:../ckan/test-core.ini
+use = config:../../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here. These will override the one defined in CKAN core's test-core.ini
@@ -12,11 +12,12 @@ ckan.plugins = push_errors
 
 ckanext.push_errors.url = http://myserver.com
 ckanext.push_errors.method = POST
-ckanext.push_errors.headers = '{"Authorization": "Token 123"}'
-ckanext.push_errors.data = '{"message": "{message}"}'
-ckanext.push_errors.title = "PUSH_ERROR *{site_url}* \nv{push_errors_version} - CKAN {ckan_version}\n{now} user: {user}\n"
+ckanext.push_errors.headers = {"Authorization": "Token 123"}
+ckanext.push_errors.data = {"message": "{message}"}
+ckanext.push_errors.title = PUSH_ERROR *{site_url}* \nv{push_errors_version} - CKAN {ckan_version}\n{now} user: {user}\n
 ckanext.push_errors.max_messages_minute = 3
 ckanext.push_errors.max_messages_hour = 10
+
 
 # Logging configuration
 [loggers]

--- a/test.ini
+++ b/test.ini
@@ -10,6 +10,14 @@ use = config:../ckan/test-core.ini
 # tests here. These will override the one defined in CKAN core's test-core.ini
 ckan.plugins = push_errors
 
+ckanext.push_errors.url = http://myserver.com
+ckanext.push_errors.method = POST
+ckanext.push_errors.headers = {"Authorization": "Token 123"}
+ckanext.push_errors.data = {"message": "{message}"}
+ckanext.push_errors.title = PUSH_ERROR *{site_url}* \nv{push_errors_version} - CKAN {ckan_version}\n{now} user: {user}\n
+ckanext.push_errors.max_messages_minute = 3
+ckanext.push_errors.max_messages_hour = 10
+
 
 # Logging configuration
 [loggers]

--- a/test.ini
+++ b/test.ini
@@ -12,12 +12,11 @@ ckan.plugins = push_errors
 
 ckanext.push_errors.url = http://myserver.com
 ckanext.push_errors.method = POST
-ckanext.push_errors.headers = {"Authorization": "Token 123"}
-ckanext.push_errors.data = {"message": "{message}"}
-ckanext.push_errors.title = PUSH_ERROR *{site_url}* \nv{push_errors_version} - CKAN {ckan_version}\n{now} user: {user}\n
+ckanext.push_errors.headers = '{"Authorization": "Token 123"}'
+ckanext.push_errors.data = '{"message": "{message}"}'
+ckanext.push_errors.title = "PUSH_ERROR *{site_url}* \nv{push_errors_version} - CKAN {ckan_version}\n{now} user: {user}\n"
 ckanext.push_errors.max_messages_minute = 3
 ckanext.push_errors.max_messages_hour = 10
-
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
fixes #11 

Necesitás agregar esta configuración en tu archivo de configuración de CKAN:

`ckanext.push_errors.message_title = {site_url} \nv{push_errors_version} - CKAN {ckan_version}\n{now} user: {user}\n`